### PR TITLE
Add comment feature to booking requests

### DIFF
--- a/ResortBooking/src/main/java/ru/nsu/resortbooking/controller/StudentController.java
+++ b/ResortBooking/src/main/java/ru/nsu/resortbooking/controller/StudentController.java
@@ -46,13 +46,14 @@ public class StudentController {
     public ResponseEntity<?> createRequest(
             Authentication auth,
             @RequestParam Long sessionId,
+            @RequestParam(value = "comment", required = false) String comment,
             @RequestParam("files") MultipartFile[] files
     ) {
         try {
             String email = auth.getName();
             User user = userService.getByEmail(email);
             Session session = sessionService.getById(sessionId);
-            BookingRequest req = requestService.createRequest(user, session);
+            BookingRequest req = requestService.createRequest(user, session, comment);
 
             for (var file : files) {
                 String path = fileStorageUtil.storeFile(file);

--- a/ResortBooking/src/main/java/ru/nsu/resortbooking/model/BookingRequest.java
+++ b/ResortBooking/src/main/java/ru/nsu/resortbooking/model/BookingRequest.java
@@ -36,6 +36,9 @@ public class BookingRequest {
     @Column(nullable = false)
     private Boolean isPaid;
 
+    @Column(length = 2048)
+    private String comment;
+
     @Column(nullable = false)
     private LocalDateTime createdAt;
 }

--- a/ResortBooking/src/main/java/ru/nsu/resortbooking/service/RequestService.java
+++ b/ResortBooking/src/main/java/ru/nsu/resortbooking/service/RequestService.java
@@ -19,7 +19,7 @@ public class RequestService {
     private final SessionService sessionService;
 
     @Transactional
-    public BookingRequest createRequest(User user, Session session) {
+    public BookingRequest createRequest(User user, Session session, String comment) {
         boolean exists = requestRepository
                 .findByUserIdAndSessionId(user.getId(), session.getId())
                 .isPresent();
@@ -32,6 +32,7 @@ public class RequestService {
                 .session(session)
                 .status(RequestStatus.PENDING)
                 .isPaid(false)
+                .comment(comment)
                 .createdAt(LocalDateTime.now())
                 .build();
         return requestRepository.save(req);

--- a/ResortBooking/src/test/java/ru/nsu/resortbooking/controller/StudentControllerTest.java
+++ b/ResortBooking/src/test/java/ru/nsu/resortbooking/controller/StudentControllerTest.java
@@ -67,11 +67,11 @@ class StudentControllerTest {
 
         when(userService.getByEmail("test@mail.ru")).thenReturn(user);
         when(sessionService.getById(1L)).thenReturn(session);
-        when(requestService.createRequest(user, session)).thenReturn(request);
+        when(requestService.createRequest(user, session, "note")).thenReturn(request);
         when(fileStorageUtil.storeFile(any())).thenReturn("stored_file.txt");
 
         ResponseEntity<?> response = studentController.createRequest(
-                authentication, 1L, new MockMultipartFile[]{file});
+                authentication, 1L, "note", new MockMultipartFile[]{file});
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         verify(documentRepository, atLeastOnce()).save(any());

--- a/ResortBooking/src/test/java/ru/nsu/resortbooking/service/RequestServiceTest.java
+++ b/ResortBooking/src/test/java/ru/nsu/resortbooking/service/RequestServiceTest.java
@@ -55,13 +55,14 @@ class RequestServiceTest {
             return req;
         });
 
-        BookingRequest request = requestService.createRequest(user, session);
+        BookingRequest request = requestService.createRequest(user, session, "note");
 
         assertNotNull(request);
         assertEquals(RequestStatus.PENDING, request.getStatus());
         assertFalse(request.getIsPaid());
         assertNotNull(request.getCreatedAt());
         verify(requestRepository, times(1)).save(any(BookingRequest.class));
+        assertEquals("note", request.getComment());
     }
 
     @Test
@@ -74,7 +75,7 @@ class RequestServiceTest {
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> requestService.createRequest(user, session)
+                () -> requestService.createRequest(user, session, "note")
         );
         assertEquals("Вы уже подали заявку на этот сеанс", exception.getMessage());
         verify(requestRepository, never()).save(any());

--- a/ResortBookingUI/resort-booking-app/src/api/requests.js
+++ b/ResortBookingUI/resort-booking-app/src/api/requests.js
@@ -8,9 +8,10 @@ export function getMyRequests() {
   return axios.get('/student/requests')
 }
 
-export function createRequest(sessionId, files) {
+export function createRequest(sessionId, files, comment) {
   const form = new FormData()
   form.append('sessionId', sessionId)
+  if (comment) form.append('comment', comment)
   files.forEach(file => form.append('files', file))
   return axios.post('/student/requests', form, {
     headers: { 'Content-Type': 'multipart/form-data' }

--- a/ResortBookingUI/resort-booking-app/src/components/Staff/RequestTable.jsx
+++ b/ResortBookingUI/resort-booking-app/src/components/Staff/RequestTable.jsx
@@ -23,6 +23,7 @@ export default function RequestTable({ requests, onApprove, onReject }) {
             <th>Вместимость</th>
             <th>Статус</th>
             <th>Опл.</th>
+            <th>Комментарий</th>
             <th>Документы</th>
             <th>Действия</th>
           </tr>
@@ -37,6 +38,7 @@ export default function RequestTable({ requests, onApprove, onReject }) {
               <td>{r.session.capacity}</td>
               <td>{statusLabels[r.status]}</td>
               <td>{r.isPaid ? 'Да' : 'Нет'}</td>
+              <td>{r.comment || ''}</td>
               <td>
                 <button onClick={() => setSelectedId(r.id)}>Просмотр</button>
               </td>

--- a/ResortBookingUI/resort-booking-app/src/components/Student/BookingForm.jsx
+++ b/ResortBookingUI/resort-booking-app/src/components/Student/BookingForm.jsx
@@ -3,6 +3,7 @@ import '../../styles/BookingForm.css'
 
 export default function BookingForm({ sessionId, onSubmit, onClose }) {
   const [files, setFiles] = useState([])
+  const [comment, setComment] = useState('')
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState('')
 
@@ -13,7 +14,7 @@ export default function BookingForm({ sessionId, onSubmit, onClose }) {
     setMessage('')
     setLoading(true)
     try {
-      await onSubmit(sessionId, files)
+      await onSubmit(sessionId, files, comment)
       setMessage('Заявка отправлена успешно')
     } catch (err) {
       const msg = err.response?.data?.error || 'Ошибка при отправке'
@@ -30,6 +31,11 @@ export default function BookingForm({ sessionId, onSubmit, onClose }) {
         {message && <p className="status">{message}</p>}
         <form onSubmit={handleSubmit}>
           <input type="file" multiple onChange={handleChange} />
+          <textarea
+            value={comment}
+            onChange={e => setComment(e.target.value)}
+            placeholder="Комментарий (необязательно)"
+          />
           <div className="modal-buttons">
             <button type="submit" disabled={loading}>
               {loading ? 'Отправка...' : 'Отправить'}

--- a/ResortBookingUI/resort-booking-app/src/components/Student/RequestList.jsx
+++ b/ResortBookingUI/resort-booking-app/src/components/Student/RequestList.jsx
@@ -17,6 +17,7 @@ export default function RequestList({ requests, onPay }) {
             <p>С {r.session.startDate} по {r.session.endDate}</p>
             <p>Статус: {statusLabels[r.status]}</p>
             <p>{r.isPaid ? 'Оплачено' : 'Не оплачено'}</p>
+            {r.comment && <p>Комментарий: {r.comment}</p>}
           </div>
           {!r.isPaid && r.status === 'APPROVED' && (
             <button onClick={() => onPay(r.id)}>Оплатить</button>

--- a/ResortBookingUI/resort-booking-app/src/pages/StudentDashboard.jsx
+++ b/ResortBookingUI/resort-booking-app/src/pages/StudentDashboard.jsx
@@ -34,8 +34,8 @@ export default function StudentDashboard() {
     setBookingSession(id)
   }
 
-  function handleSubmit(sessionId, files) {
-    createRequest(sessionId, files)
+  function handleSubmit(sessionId, files, comment) {
+    createRequest(sessionId, files, comment)
       .then(() => {
         setBookingSession(null)
         refreshAll()


### PR DESCRIPTION
## Summary
- allow students to add a comment when creating a request
- store the comment in `BookingRequest`
- expose the comment through the REST API and UI
- display comments to staff and students
- update unit tests

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f93f2e7b083238d478b0fb3f8b788